### PR TITLE
Fix JSON examples in session-requests

### DIFF
--- a/docs/session-requests.md
+++ b/docs/session-requests.md
@@ -140,7 +140,7 @@ Within inner conjunctions, specific attribute values can be requested by replaci
     [
       [
         { "type": "pbdf.pbdf.diploma.degree", "value": "PhD" },
-        { "type": "pbdf.pbdf.diploma.institute", "value": null },
+        { "type": "pbdf.pbdf.diploma.institute", "value": null }
       ]
     ]
   ]
@@ -211,7 +211,7 @@ A disjunction within a session request can be marked as *optional*, by including
   "@context": "https://irma.app/ld/request/disclosure/v2",
   "disclose": [
     [
-      [ "irma-demo.nijmegen.address.city" ],
+      [ "irma-demo.nijmegen.address.city" ]
     ],
     [
       [],

--- a/website/versioned_docs/version-v0.3.0/session-requests.md
+++ b/website/versioned_docs/version-v0.3.0/session-requests.md
@@ -142,7 +142,7 @@ Within inner conjunctions, specific attribute values can be requested by replaci
     [
       [
         { "type": "pbdf.pbdf.diploma.degree", "value": "PhD" },
-        { "type": "pbdf.pbdf.diploma.institute", "value": null },
+        { "type": "pbdf.pbdf.diploma.institute", "value": null }
       ]
     ]
   ]
@@ -213,7 +213,7 @@ A disjunction within a session request can be marked as *optional*, by including
   "@context": "https://irma.app/ld/request/disclosure/v2",
   "disclose": [
     [
-      [ "irma-demo.nijmegen.address.city" ],
+      [ "irma-demo.nijmegen.address.city" ]
     ],
     [
       [],

--- a/website/versioned_docs/version-v0.3.1/session-requests.md
+++ b/website/versioned_docs/version-v0.3.1/session-requests.md
@@ -142,7 +142,7 @@ Within inner conjunctions, specific attribute values can be requested by replaci
     [
       [
         { "type": "pbdf.pbdf.diploma.degree", "value": "PhD" },
-        { "type": "pbdf.pbdf.diploma.institute", "value": null },
+        { "type": "pbdf.pbdf.diploma.institute", "value": null }
       ]
     ]
   ]
@@ -213,7 +213,7 @@ A disjunction within a session request can be marked as *optional*, by including
   "@context": "https://irma.app/ld/request/disclosure/v2",
   "disclose": [
     [
-      [ "irma-demo.nijmegen.address.city" ],
+      [ "irma-demo.nijmegen.address.city" ]
     ],
     [
       [],


### PR DESCRIPTION
During implementing a client library I noticed that the session-requests in the documentation are not valid JSON. This MR should fix all cases. 