### PR TITLE
Handle URL fix to explicitly match all suburls

### DIFF
--- a/docs/irma-server-lib.md
+++ b/docs/irma-server-lib.md
@@ -46,7 +46,7 @@ func main() {
 	   	// ...
 	}
 
-	http.Handle("/irma", irmaserver.HandlerFunc())
+	http.Handle("/irma/", irmaserver.HandlerFunc())
 	http.HandleFunc("/createrequest", createFullnameRequest)
 
 	// Start the server


### PR DESCRIPTION
If this example code is used when also having a `http.Handle("/", ...)` endpoint, the `irma/..../....` endpoints will be routed to the wrong location. Adding an extra `/` solves this, because then also all suburls are being served.