### PR TITLE
Space fix

### DIFF
--- a/docs/irma-server.md
+++ b/docs/irma-server.md
@@ -113,7 +113,7 @@ Unlike normal QRs which differ per session (as they contain the session token), 
             "callbackUrl": "https://example.com/callbackUrl",
             "request": {
                 "@context": "https://irma.app/ld/request/disclosure/v2",
-                "disclose": [[[ "irma-demo.MijnOverheid.ageLower" ]]]
+                "disclose": [[[ "irma-demo.MijnOverheid.ageLower.over18" ]]]
             }
         }
     }

--- a/docs/irma-server.md
+++ b/docs/irma-server.md
@@ -127,7 +127,7 @@ Assuming the URL of the `irma server` is `http://example.com`, the session confi
 ```json
 {
     "irmaqr": "redirect",
-    "u":" http://example.com/irma/session/mystaticsession"
+    "u": "http://example.com/irma/session/mystaticsession"
 }
 ```
 


### PR DESCRIPTION
The space is in the URL string, so when using exactly this request `irmago` will complain.