### PR TITLE
Fix outdated session status check in chained sessions example

### DIFF
--- a/docs/chained-sessions.md
+++ b/docs/chained-sessions.md
@@ -79,8 +79,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Perform sanity checks on the session result
-	if result.Status != server.StatusDone ||
+	// Perform sanity checks on the session result.
+	// NB: this endpoint is called by the IRMA server just before it ends the
+	// session, so the session status is expected to be server.StatusConnected
+	// (or the JSON string "CONNECTED").
+	if result.Status != server.StatusConnected ||
 		result.ProofStatus != irma.ProofStatusValid ||
 		len(result.Disclosed) == 0 || len(result.Disclosed[0]) == 0 ||
 		result.Disclosed[0][0].Identifier.String() != "irma-demo.gemeente.personalData.fullname" ||


### PR DESCRIPTION
Recently [`irmago` was changed](https://github.com/privacybydesign/irmago/pull/155) to invoke the next session URL just before it sets the session status to `DONE`, so that when the URL is invoked, the session status is in fact `CONNECTED`. This PR updates the example in the next session page to reflect this.