### PR TITLE
Update delivery pipeline to use latest tag when run from master

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=staging
+            type=raw,value=${{ github.ref == 'refs/heads/master' && 'latest' || 'staging' }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ docker compose up
 ## Release
 To release a new version run the Github action located [here](https://github.com/privacybydesign/irma-documentation/actions/workflows/delivery.yml). This will push a new Docker build to Github packages:
 https://github.com/privacybydesign/irma-documentation/pkgs/container/irma-documentation
+
+### Note on delivery.yml pipeline behavior
+When the `delivery.yml` pipeline is run from the master branch, it will use the latest tag. If the pipeline is not run from the master branch, it will use the staging tag.


### PR DESCRIPTION
Update the `delivery.yml` pipeline to use different tags based on the branch it is run from.

* **README.md**
  - Add a note about the new behavior of the `delivery.yml` pipeline.
  - Mention that the pipeline now uses the latest tag when run from master.
  - Mention that the pipeline uses the staging tag when not run from master.

* **.github/workflows/delivery.yml**
  - Add a condition to check if the pipeline is run from the master branch.
  - Modify the `tags` value to use the latest tag when run from master.
  - Modify the `tags` value to use the staging tag when not run from master.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/privacybydesign/irma-documentation/pull/71?shareId=c1809043-5268-4eb7-8a4b-a8f88d2ca8d3).