### PR TITLE
fix: edit link

### DIFF
--- a/yivi-docs/docusaurus.config.ts
+++ b/yivi-docs/docusaurus.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/privacybydesign/irma-documentation/tree/master/yivi-docs/',
         },
         blog: {
           showReadingTime: true,
@@ -57,7 +57,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/privacybydesign/irma-documentation/tree/master/yivi-docs/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',


### PR DESCRIPTION
Changed the editUrl from the default docusaurus link to the correct documentation link.