### PR TITLE
Update session request documentation with needed content type header

### DIFF
--- a/yivi-docs/docs/session-requests.md
+++ b/yivi-docs/docs/session-requests.md
@@ -478,10 +478,14 @@ Below you can find an overview of all extra parameters and their default value.
 More information about session lifetimes and timeouts can be found in the [IRMA server documentation](irma-server.md#session-lifetime).
 
 ## JWTs: signed session requests
-The IRMA API server or [`irma server`](irma-server.md) can be configured such that it only accepts session requests that have been digitally signed in the form of a [JWT](https://jwt.io). The form of the JWT depends on the [session type](what-is-yivi.md#session-types). An example requesting [YiviTube](https://yivitube.yivi.app/) attributes::
+The IRMA API server or [`irma server`](irma-server.md) can be configured to only accept session requests that have been digitally signed using a signed JWT, according to the [JWT (RFC 7519)](https://datatracker.ietf.org/doc/html/rfc7519) and [JWS (RFC 7515)](https://datatracker.ietf.org/doc/html/rfc7515) standards. These signed session requests are JWS objects (signed JWTs) that encapsulate the session request data. Set the HTTP `Content-Type` header to `text/plain` when sending a signed session request.
+
+An example requesting [YiviTube](https://yivitube.yivi.app/) attributes:
+
 ```
 eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImlybWF0dWJlIn0.eyJpYXQiOjE1NjQ2NTczNzUsInN1YiI6InZlcmlmaWNhdGlvbl9yZXF1ZXN0Iiwic3ByZXF1ZXN0Ijp7InJlcXVlc3QiOnsiQGNvbnRleHQiOiJodHRwczovL2lybWEuYXBwL2xkL3JlcXVlc3QvZGlzY2xvc3VyZS92MiIsImRpc2Nsb3NlIjpbW1sicGJkZi5wYmRmLmlybWF0dWJlLnR5cGUiXV0sW1sicGJkZi5wYmRmLmFnZUxpbWl0cy5vdmVyMTIiXSxbInBiZGYuZ2VtZWVudGUucGVyc29uYWxEYXRhLm92ZXIxMiJdXV19fX0.lW9mqjrLkoahDP6Fcw_9mH5hlfl1tq5qp3W3ga0Nrd_j0NXFj-6ngqHVXEV1zhC_OkVH4LN8fMBAgN8nqaFWgEdQvrCuB7-ynuBVjLR-QU272Ym86zLEWYggAkbZ5KY40MpTxU1dgFMucG7fyAESic04OribWOCVxstAMsM28yCxvzkBMCOSjFEe3abcg_N6VvQnLn3LgZP_UrxQmQsh4DK7mBjW04LesLG1vjcliyhDGUb52FHOP_NAsG7G2FvIgojPzALlPrpTMu5p8a95wc5CGR791wybmh0F8kDdwZWAU0W2FjlX5bNPsyXN8AxRVWaRmWoGrGsQhy_sKEf8lg
 ```
+
 In case of disclosure sessions, the body of the JWT (the part in between the two dots) contains a Base64-encoding of the following:
 
 <Tabs>


### PR DESCRIPTION
When I was implementing the requestor authentication I guessed the needed content type of the request but my gues was incorrect and I needed to look it up in the code after seeing the error code in the log. 

I missed the information about the content type in the documentation.

I found the expected content type in the code:
https://github.com/privacybydesign/irmago/blob/773a229329a063043831a4c21e72b139b9600f4b/server/requestorserver/auth.go#L276-L278
