### PR TITLE
docs: yivi frontend packages v0 to v1 migration guide

### DIFF
--- a/yivi-docs/docs/api-yivi-frontend.md
+++ b/yivi-docs/docs/api-yivi-frontend.md
@@ -6,17 +6,17 @@ The Yivi frontend packages consist of multiple packages. Therefore we describe t
 The API description of the Yivi frontend plugins is combined into one section.
 
 ## Yivi core
-The [Yivi core](yivi-frontend.md#yivi-core) package only exports the `YiviCore` class. To handle an IRMA session, 
+The [Yivi core](yivi-frontend.md#yivi-core) package exports the `YiviCore` class as a named export. To handle an IRMA session, 
 an instance of this class can be made with the relevant options for your session. The options object is shared
 between all plugins that are registered at the `YiviCore` instance. The plugins don't need to be configured
 individually. The options that can be specified depend on the specific plugins you are using. You can find all 
 possible options in the READMEs of the plugins. You can find an overview of all available Yivi core plugins
 [here](#plugins).
 
-The Yivi core class has one constructor:
+The Yivi core class can be imported and instantiated as follows:
 ```javascript
-const YiviCore = require('@privacybydesign/yivi-core');
-const yivi     = new YiviCore({/* Options */});
+import { YiviCore } from '@privacybydesign/yivi-core';
+const yivi = new YiviCore({/* Options */});
 ```
 
 Below you can find an overview of all methods an Yivi core instance offers you.
@@ -50,6 +50,11 @@ Both functions return an interface with the following methods:
 
 When importing this library via a `<script>` tag in HTML the JavaScript variable `yivi` will be bound to this library.
 In these environments you can therefore directly access the exported functions by for instance saying `yivi.newWeb(...)`.
+
+When using ES modules or CommonJS, import the named exports directly:
+```javascript
+import { newWeb, newPopup } from '@privacybydesign/yivi-frontend';
+```
 
 ## Plugins
 The [plugins](yivi-frontend.md#available-plugins-for-yivi-core) do not export any class or method. They only add extra

--- a/yivi-docs/docs/yivi-frontend-migration.md
+++ b/yivi-docs/docs/yivi-frontend-migration.md
@@ -5,6 +5,44 @@ title: "Migrating Yivi frontend packages from v0 to v1"
 This guide covers all breaking changes when upgrading from `@privacybydesign/yivi-*` v0.x to v1.0
 and provides step-by-step migration instructions.
 
+## Why v1.0?
+
+The v0.x packages were originally published as plain CommonJS with no TypeScript support, bundled
+Node.js polyfills for browser-irrelevant APIs, and relied on default exports — all of which caused
+real integration issues as the JavaScript ecosystem moved forward. v1.0 is a modernization release
+that addresses these problems:
+
+- **ESM-first with dual CJS/ESM builds.** The v0.x packages were CJS-only, which forced users of
+  modern bundlers like Vite to add workarounds (`optimizeDeps.include`, manual CJS-to-ESM
+  pre-bundling). Packages now ship both formats with a proper `"exports"` field, so they work
+  natively in all environments without bundler configuration.
+
+- **No more Node.js polyfill breakage in browsers.** The v0.x `yivi-client` depended on
+  `isomorphic-fetch` and the `eventsource` npm package. The latter pulled in `util.inherits`
+  (a Node.js-only API), which broke browser bundles and required consumers to create stub files and
+  resolve aliases to work around it. These polyfills are removed — native `fetch` is used directly,
+  and the client falls back to HTTP polling when `EventSource` is unavailable.
+
+- **Named exports for better tooling.** Default exports cause naming inconsistencies across
+  codebases, break tree-shaking in some bundlers, and make IDE auto-imports less reliable. All
+  packages now use named exports exclusively.
+
+- **TypeScript support out of the box.** All packages are now written in TypeScript and ship
+  declaration files. Consumers get type checking and editor autocompletion without installing
+  separate `@types/` packages.
+
+- **Improved accessibility.** Interactive elements (cancel, retry, back) are now semantic `<button>`
+  elements instead of `<a>` tags, and focus outlines are no longer suppressed.
+
+- **First-class minimal rendering mode.** Multiple consumers needed to show just the QR code without
+  the surrounding form wrapper, and resorted to aggressive CSS overrides
+  (`all: revert !important`, complex `:not()` selectors) to achieve this. The new `minimal: true`
+  option provides this natively.
+
+For most projects, upgrading to v1.0 consists of changing default imports to named imports and
+removing polyfill workarounds. The rest of the API — constructor options, plugin registration,
+session configuration — is unchanged.
+
 ## Named exports replace default exports
 
 All packages now use **named exports** instead of default exports. This is the change most likely to

--- a/yivi-docs/docs/yivi-frontend-migration.md
+++ b/yivi-docs/docs/yivi-frontend-migration.md
@@ -1,0 +1,315 @@
+---
+title: "Migrating Yivi frontend packages from v0 to v1"
+---
+
+This guide covers all breaking changes when upgrading from `@privacybydesign/yivi-*` v0.x to v1.0
+and provides step-by-step migration instructions.
+
+## Named exports replace default exports
+
+All packages now use **named exports** instead of default exports. This is the change most likely to
+affect your code.
+
+**Before (v0.x):**
+```javascript
+// ES modules
+import YiviCore from '@privacybydesign/yivi-core';
+import YiviWeb from '@privacybydesign/yivi-web';
+import YiviClient from '@privacybydesign/yivi-client';
+
+// CommonJS
+const YiviCore = require('@privacybydesign/yivi-core');
+```
+
+**After (v1.0):**
+```javascript
+// ES modules
+import { YiviCore } from '@privacybydesign/yivi-core';
+import { YiviWeb } from '@privacybydesign/yivi-web';
+import { YiviClient } from '@privacybydesign/yivi-client';
+
+// CommonJS
+const { YiviCore } = require('@privacybydesign/yivi-core');
+```
+
+This applies to all packages: `yivi-core`, `yivi-client`, `yivi-web`, `yivi-popup`, `yivi-console`, and `yivi-dummy`.
+
+If you use **dynamic imports**, the same change applies:
+```javascript
+// Before (v0.x)
+const YiviCore = (await import('@privacybydesign/yivi-core')).default;
+
+// After (v1.0)
+const { YiviCore } = await import('@privacybydesign/yivi-core');
+```
+
+### yivi-frontend
+
+The `yivi-frontend` convenience package also switched to named exports:
+
+**Before (v0.x):**
+```javascript
+const yivi = require('@privacybydesign/yivi-frontend');
+const session = yivi.newWeb({ ... });
+```
+
+**After (v1.0):**
+```javascript
+import { newWeb, newPopup } from '@privacybydesign/yivi-frontend';
+const session = newWeb({ ... });
+```
+
+When loading `yivi-frontend` via a `<script>` tag, the global `yivi.newWeb(...)` / `yivi.newPopup(...)` API
+remains unchanged.
+
+## ESM-first module system
+
+All packages now set `"type": "module"` in their `package.json` and ship dual ESM/CJS builds
+through the `"exports"` field:
+
+- `dist/index.mjs` (ESM)
+- `dist/index.cjs` (CJS)
+- `dist/index.d.mts` / `dist/index.d.cts` (TypeScript declarations)
+
+### What this means for your project
+
+- **Static ESM imports work natively** in bundlers and Node.js without extra configuration.
+- **Deep imports into source files no longer work.** Only the documented package entry points are
+  accessible. If you were importing internal files like
+  `@privacybydesign/yivi-core/state-transitions`, those paths are no longer available.
+- **Vite users:** v0.x was CJS-only, so you may have needed `optimizeDeps.include` to force
+  CJS-to-ESM conversion during pre-bundling. This is no longer required for static imports. However,
+  if you use **dynamic imports** (`await import(...)`) for the yivi packages, you may still want
+  `optimizeDeps.include` so Vite can discover them at dev server startup:
+  ```javascript
+  // vite.config.js
+  export default {
+    optimizeDeps: {
+      include: [
+        '@privacybydesign/yivi-core',
+        '@privacybydesign/yivi-web',
+        '@privacybydesign/yivi-client',
+      ],
+    },
+  };
+  ```
+
+## Removed dependencies: `isomorphic-fetch` and `eventsource`
+
+### `isomorphic-fetch` removed
+
+`yivi-client` no longer ships `isomorphic-fetch`. The global `fetch` API is assumed to be available,
+which is the case in all modern browsers and Node.js 18+.
+
+**Action required:** If your project targets Node.js < 18, you must provide your own `fetch` polyfill.
+
+### `eventsource` polyfill removed
+
+`yivi-client` no longer bundles the `eventsource` npm package as a Node.js polyfill for Server-Sent
+Events. When native `EventSource` is unavailable, the client automatically falls back to HTTP polling.
+
+**Action required:** If you had workarounds for the `eventsource` dependency (browser stubs, Vite
+resolve aliases, etc.), you can safely remove them:
+
+```javascript
+// vite.config.js — you can remove this:
+resolve: {
+  alias: {
+    eventsource: './src/stubs/eventsource.ts',
+  },
+},
+```
+
+If you relied on SSE for server status updates in Node.js, you will now get polling instead. No code
+changes are needed, but be aware that polling has slightly different timing characteristics.
+
+## TypeScript support
+
+All packages now ship TypeScript declaration files (`.d.mts` / `.d.cts`). Key types exported from
+`@privacybydesign/yivi-core` include:
+
+| Type | Description |
+|---|---|
+| `YiviOptions` | Full options object passed to the `YiviCore` constructor |
+| `YiviSessionOptions` | The `session` sub-object of options |
+| `YiviStateOptions` | The `state` sub-object of options |
+| `YiviState` | Union of all state machine states |
+| `StateChangeEvent` | Shape of the object passed to plugin `stateChange` callbacks |
+| `YiviPlugin` / `YiviPluginConstructor` | Interfaces for writing custom plugins |
+| `SessionPtr` / `FrontendRequest` | Session-related types |
+
+## Peer dependencies
+
+Plugins now formally declare `@privacybydesign/yivi-core` as a peer dependency. Make sure
+`yivi-core` is installed alongside any plugins you use. Most package managers handle this
+automatically, but you may see warnings if `yivi-core` is missing.
+
+```json
+{
+  "dependencies": {
+    "@privacybydesign/yivi-core": "^1.0.0",
+    "@privacybydesign/yivi-client": "^1.0.0",
+    "@privacybydesign/yivi-web": "^1.0.0",
+    "@privacybydesign/yivi-css": "^1.0.0"
+  }
+}
+```
+
+## `yivi-console` sub-path exports
+
+`yivi-console` now uses explicit sub-path exports for Node.js and browser environments, replacing
+the automatic resolution via the `"browser"` field in `package.json`.
+
+**Before (v0.x):**
+```javascript
+// Automatically resolved to node.js or web.js based on environment
+const YiviConsole = require('@privacybydesign/yivi-console');
+```
+
+**After (v1.0):**
+```javascript
+import { YiviConsole } from '@privacybydesign/yivi-console/node';  // Node.js
+import { YiviConsole } from '@privacybydesign/yivi-console/web';   // Browser
+import { YiviConsole } from '@privacybydesign/yivi-console';       // Generic
+```
+
+## DOM changes: `<a>` tags replaced with `<button>` elements
+
+Interactive elements in the rendered Yivi UI (cancel, retry, back, show QR) are now semantic
+`<button>` elements instead of `<a>` tags:
+
+| Element | v0.x | v1.0 |
+|---|---|---|
+| Cancel | `<a data-yivi-glue-transition="cancel">` | `<button class="yivi-web-button-secondary">` |
+| Retry | `<a>` | `<button class="yivi-web-button-secondary">` |
+| Back | `<a>` | `<button class="yivi-web-button-tertiary">` |
+| Show QR | `<a>` | `<button class="yivi-web-button-secondary">` |
+
+**Action required:** If you have custom CSS targeting anchor tags inside the Yivi form (e.g.,
+`.yivi-web-content a` or `a[data-yivi-glue-transition]`), update those selectors to target `button`
+elements instead.
+
+## CSS changes
+
+### New CSS classes
+
+| Class | Purpose |
+|---|---|
+| `.yivi-web-button-secondary` | Outlined button style (cancel, retry, show QR) |
+| `.yivi-web-button-tertiary` | Text-link-style button (back) |
+| `.yivi-web-minimal` | Wrapper class for the new [minimal mode](#minimal-mode) |
+
+### Changed styles
+
+- **Font sizes:** Fixed `px`-based font sizes have been removed from header and content paragraph
+  elements. The Yivi form now inherits font sizes from the parent page. If you depended on the
+  specific pixel values, you may need to set font sizes in your own CSS.
+- **Button focus outlines:** The `outline: 0` rule on `:focus` has been removed. Buttons now show
+  the browser's default focus outline, improving keyboard accessibility.
+- **Button hover/active states:** `.yivi-web-button` now has `box-shadow` on hover and `translateY`
+  on active for visual feedback.
+- **QR code rendering:** `image-rendering: pixelated` is now applied to `.yivi-web-qr-code` for
+  sharper QR codes.
+- **Anchor styling removed:** The CSS block that styled `.yivi-web-content a` has been removed,
+  since interactive anchors have been replaced with buttons.
+
+### Sass partials: `@import` replaced with `@use`
+
+If you import individual SCSS partials from `yivi-css/src/` in your own Sass files, you need to
+migrate from `@import` to `@use`/`@forward`:
+
+**Before (v0.x):**
+```scss
+@import '@privacybydesign/yivi-css/src/variables';
+@import '@privacybydesign/yivi-css/src/mixins';
+```
+
+**After (v1.0):**
+```scss
+@use '@privacybydesign/yivi-css/src/variables' as *;
+@use '@privacybydesign/yivi-css/src/mixins' as *;
+```
+
+If you only consume the compiled CSS file (`dist/yivi.css`), this does not affect you.
+
+## Minimal mode {#minimal-mode}
+
+v1.0 introduces a `minimal` option for `yivi-web` that renders only the QR code and status
+animations, without the surrounding form wrapper. This is useful when you want to embed the QR code
+in your own custom UI without fighting the default form styles.
+
+```javascript
+const yivi = new YiviCore({
+  element: '#yivi-container',
+  minimal: true,
+  session: { ... },
+});
+
+yivi.use(YiviWeb);
+yivi.use(YiviClient);
+yivi.start();
+```
+
+If you were using CSS hacks in v0.x to hide the form wrapper and only show the QR code (e.g.,
+`.yivi-web-content { all: revert !important; }` or similar overrides), you can now replace those with
+`minimal: true` and remove the custom CSS.
+
+## Deprecated state machine methods
+
+The `transition()` and `finalTransition()` methods on the state machine are deprecated.
+Use `selectTransition()` instead, which automatically determines whether the transition is final
+based on the target state.
+
+**Before (v0.x):**
+```javascript
+stateMachine.transition('abort', 'User cancelled');
+stateMachine.finalTransition('abort', 'User cancelled');
+```
+
+**After (v1.0):**
+```javascript
+stateMachine.selectTransition('abort', 'User cancelled');
+```
+
+## Node.js minimum version
+
+The minimum supported Node.js version is now **18**, due to the reliance on native `fetch` and
+native ESM support. CI tests run on Node.js 22.
+
+## `yivi-css` import in bundlers
+
+The `yivi-css` package's main entry points to a CSS file, which some bundlers cannot resolve as a
+JavaScript import. If your bundler has trouble importing `@privacybydesign/yivi-css`, use a resolve
+alias or import the CSS file path directly:
+
+```javascript
+// Direct import
+import '@privacybydesign/yivi-css/dist/yivi.css';
+```
+
+```javascript
+// Or add a Vite/webpack alias
+// vite.config.js
+export default {
+  resolve: {
+    alias: {
+      '@privacybydesign/yivi-css': '@privacybydesign/yivi-css/dist/yivi.css',
+    },
+  },
+};
+```
+
+## Migration checklist
+
+- [ ] Update all imports from default to named exports (`import { YiviCore }` instead of `import YiviCore`)
+- [ ] Update `yivi-frontend` usage to named exports (`import { newWeb }` instead of `yivi.newWeb`)
+- [ ] Update `yivi-console` imports to use sub-path exports (`/node` or `/web`)
+- [ ] Ensure Node.js >= 18 is used in your project
+- [ ] Remove `eventsource` polyfills, stubs, or resolve aliases
+- [ ] Remove `isomorphic-fetch` polyfills
+- [ ] Remove `optimizeDeps.include` for yivi packages (if using static imports with Vite)
+- [ ] Update custom CSS selectors from `a` to `button` for interactive elements inside the Yivi form
+- [ ] If importing SCSS partials: migrate `@import` to `@use`
+- [ ] Consider using `minimal: true` if you had CSS hacks to hide the form wrapper
+- [ ] Ensure `yivi-core` is installed alongside plugins (now a peer dependency)
+- [ ] Replace `stateMachine.transition()` / `finalTransition()` with `selectTransition()` in custom plugins

--- a/yivi-docs/docs/yivi-frontend.md
+++ b/yivi-docs/docs/yivi-frontend.md
@@ -16,6 +16,11 @@ Using the default styling, the browser version will look like this:
 
 All packages are published on [npm](https://www.npmjs.com/) in `@privacybydesign` scoped packages.
 
+:::info Migrating from v0.x?
+If you are upgrading from `@privacybydesign/yivi-*` v0.x, see the [migration guide](yivi-frontend-migration.md) for a
+full list of breaking changes and step-by-step upgrade instructions.
+:::
+
 ## Yivi core
 
 This package contains the [state machine](https://github.com/privacybydesign/yivi-frontend-packages/blob/master/yivi-core/state-transitions.js)
@@ -25,8 +30,9 @@ The plugins can also request state modifications to the state machine.
 
 Yivi core can be initialized in the following way:
 ```javascript
-const YiviCore = require('@privacybydesign/yivi-core');
-const yivi     = new YiviCore(/* options */);
+import { YiviCore } from '@privacybydesign/yivi-core';
+
+const yivi = new YiviCore(/* options */);
 
 yivi.use(/* Plugin A */);
 yivi.use(/* Plugin B */);
@@ -75,9 +81,9 @@ We also import the [`yivi-css`](#yivi-css) styling to nicely style our `yivi-web
 
 In our JavaScript we import `yivi-core` and the relevant plugins first.
 ```javascript
-const YiviCore   = require('@privacybydesign/yivi-core');
-const YiviWeb    = require('@privacybydesign/yivi-web');
-const YiviClient = require('@privacybydesign/yivi-client');
+import { YiviCore } from '@privacybydesign/yivi-core';
+import { YiviWeb } from '@privacybydesign/yivi-web';
+import { YiviClient } from '@privacybydesign/yivi-client';
 ```
 
 Then we can instantiate Yivi core. Let's assume we already have an endpoint `/get-irma-session`
@@ -158,12 +164,12 @@ particular plugin on GitHub. There are links in the plugin overview [above](#ava
 
 ## Yivi frontend
 For convenience we already bundled `yivi-core`, `yivi-web`, `yivi-popup` and `yivi-client` together with the default styling
-from `yivi-css`. We also added polyfills in this package to realize support for Internet Explorer 11.
+from `yivi-css`.
 The package can be installed from the npm registry.
 The bundled package can also be downloaded directly [here](https://github.com/privacybydesign/yivi-frontend-packages/releases/latest/download/yivi.js).
 Please host this file as asset yourself.
 
-The bundle can be imported in your JavaScript file by doing `require('@privacybydesign/yivi-frontend')` or it can
+The bundle can be imported in your JavaScript file by doing `import { newWeb, newPopup } from '@privacybydesign/yivi-frontend'` or it can
 be included directly in the HTML.
 
 ```html
@@ -172,7 +178,9 @@ be included directly in the HTML.
 
 You can then instantiate `yivi-frontend` and start a session like this when using an embedded web element:
 ```javascript
-const exampleWeb = yivi.newWeb({
+import { newWeb } from '@privacybydesign/yivi-frontend';
+
+const exampleWeb = newWeb({
   debugging: false,            // Enable to get helpful output in the browser console
   element:   '#yivi-web-form', // Which DOM element to render to
 
@@ -189,9 +197,11 @@ exampleWeb.start()
 .catch(error => console.error("Couldn't do what you asked 😢", error));
 ```
 
-When you want a popup overlay to be used to, you can do the following:
+When you want a popup overlay to be used, you can do the following:
 ```javascript
-const examplePopup = yivi.newPopup({
+import { newPopup } from '@privacybydesign/yivi-frontend';
+
+const examplePopup = newPopup({
   debugging: false, // Enable to get helpful output in the browser console
 
   // Back-end options
@@ -206,6 +216,9 @@ examplePopup.start()
 .then(result => console.log("Successful disclosure! 🎉", result))
 .catch(error => console.error("Couldn't do what you asked 😢", error));
 ```
+
+When including the bundle via a `<script>` tag in HTML, the JavaScript variable `yivi` will be bound to this library.
+In these environments you can access the exported functions by saying `yivi.newWeb(...)` or `yivi.newPopup(...)`.
 
 Be aware that you can start an instance of `yivi-frontend` only once.
 When you want to call `start()` again, you have to create a new instance.
@@ -259,11 +272,11 @@ design and build a new, customized style. This can be done in the following way:
    managing the session state we recommend you to use the `yivi-client` plugin.
    
 ```javascript
-require('assets/my-custom-yivi-css-design.min.css');
+import '@privacybydesign/yivi-css/dist/yivi.css';
 
-const YiviCore   = require('@privacybydesign/yivi-core');
-const YiviWeb    = require('@privacybydesign/yivi-web');
-const YiviClient = require('@privacybydesign/yivi-client');
+import { YiviCore } from '@privacybydesign/yivi-core';
+import { YiviWeb } from '@privacybydesign/yivi-web';
+import { YiviClient } from '@privacybydesign/yivi-client';
 
 const yivi = new YiviCore({
   debugging: true,
@@ -323,28 +336,34 @@ class YiviPlugin {
 }
 ```
 
-A plugin can request the state machine to make changes. This can be done using the `transition` and
-`finalTransition` methods of the `stateMachine`. The first parameter of these functions is the requested
+A plugin can request the state machine to make changes. This can be done using the `selectTransition`
+method of the `stateMachine`. The first parameter of this function is the requested
 transition. The possible transitions can be found in the [state machine](https://github.com/privacybydesign/yivi-frontend-packages/blob/master/yivi-core/state-transitions.js).
 As second parameter `payload` can be added to the transition. The payload can then be accessed by all other plugins
-as it is one of the parameters of the `stateChange` method. When requesting a `finalTransition`, the state
-machine will be locked in the new state. From then no transitions can be made anymore. For a `finalTransition`
+as it is one of the parameters of the `stateChange` method. When requesting a final transition, the state
+machine will be locked in the new state. From then no transitions can be made anymore. For a final transition
 the potential `newState` must be in the list of possible end states. Otherwise, an error is returned. After
-a `finalTransition` the `close` method of the plugin is called to close the plugin's state. This method should
+a final transition the `close` method of the plugin is called to close the plugin's state. This method should
 return a Promise which resolves when the plugin finishes closing. When the `close` Promises of all plugins are
 resolved, the promise returned by the `start` method of `YiviCore` will resolve or reject (depending on the
 transaction). In this way we can guarantee that plugins are not active anymore when the promise returned by the
-`start` method of `YiviCore` is finished. Besides when calling `finalTransition`, the closing procedure can also
-be activated when the `transition` method is used and the state machine gets in a state from which no
+`start` method of `YiviCore` is finished. The closing procedure is also
+activated when the `selectTransition` method is used and the state machine gets in a state from which no
 transitions are possible anymore.
 
 For example, in the `YiviPopup` plugin the user can press on the close button in the UI to abort the session.
 When this happens the `YiviPopup` plugin must request a state change at the Yivi core state machine to
 notify all other plugins that the new state becomes `Aborted`. This is done in the following way:
 ```javascript
-stateMachine.transition('abort', 'Popup closed');
+stateMachine.selectTransition('abort', 'Popup closed');
 ```
 
 There are no transitions possible anymore from the state `Aborted`. This means that unless the transition
 is not explicitly marked as final, the `stateChange` method of your plugin will be called with `isFinal` set
 to true.
+
+:::note
+The `transition()` and `finalTransition()` methods on the state machine are deprecated as of v1.0.
+Use `selectTransition()` instead, which automatically determines whether the transition is final based
+on the target state.
+:::

--- a/yivi-docs/sidebars.ts
+++ b/yivi-docs/sidebars.ts
@@ -39,6 +39,7 @@ const sidebars: SidebarsConfig = {
         "irma-server-lib",
         "irma-backend",
         "yivi-frontend",
+        "yivi-frontend-migration",
         "schemes",
         "issuer",
         "session-requests",


### PR DESCRIPTION
## Summary

- Adds a new **migration guide** (`yivi-frontend-migration.md`) documenting all breaking changes between `@privacybydesign/yivi-*` v0.x and v1.0
- Updates existing `yivi-frontend.md` and `api-yivi-frontend.md` to use v1 syntax (named imports, ESM)
- Adds the migration page to the sidebar under "Concepts"

### Breaking changes documented

1. **Named exports** replace default exports (`import { YiviCore }` instead of `import YiviCore`)
2. **ESM-first module system** with dual CJS/ESM builds and `"exports"` field
3. **Removed `isomorphic-fetch` and `eventsource`** polyfills — native `fetch` assumed (Node.js 18+)
4. **TypeScript declarations** now shipped
5. **Peer dependencies** introduced for plugins
6. **`yivi-console` sub-path exports** (`/node`, `/web`)
7. **DOM: `<a>` replaced with `<button>`** for interactive elements
8. **CSS changes** — new button classes, removed fixed font sizes, Sass `@import` to `@use`
9. **New `minimal: true` mode** for `yivi-web`
10. **Deprecated `transition()`/`finalTransition()`** in favor of `selectTransition()`
11. **Node.js 18+ minimum** version requirement

## Test plan

- [x] `npm run build` succeeds without errors
- [x] Verify the migration guide renders correctly on the deployed site
- [x] Verify sidebar navigation includes the migration page under "Concepts"
- [x] Verify all internal doc links work