### PR TITLE
docs: drop irma-server admin email section

### DIFF
--- a/yivi-docs/docs/getting-started.md
+++ b/yivi-docs/docs/getting-started.md
@@ -156,7 +156,6 @@ In production, it is generally best to [authenticate incoming session requests](
 
 ```yaml title="config.yml"
 production: true
-email: "example@example.com"  # see https://docs.yivi.app/irma-server#email
 
 port: 443
 url: "https://example.com/irma/"

--- a/yivi-docs/docs/irma-server-lib.md
+++ b/yivi-docs/docs/irma-server-lib.md
@@ -15,10 +15,6 @@ go get github.com/privacybydesign/irmago
 ## Configuring
 The server is configured by passing a `server.Configuration` instance to `irmaserver.New()`. For the options and their meaning, see [Godoc](https://godoc.org/github.com/privacybydesign/irmago/server/#Configuration).
 
-## Email
-
-Users are encouraged to provide an email address with the `Email` option in the `server.Configuration` struct, subscribing for notifications about changes in the IRMA software or ecosystem. [More information](irma-server.md#email).
-
 ## Example
 
 ```go

--- a/yivi-docs/docs/irma-server.md
+++ b/yivi-docs/docs/irma-server.md
@@ -65,7 +65,6 @@ When running the server in production, you should enable the `production` option
 * `url` from `"http://$YOUR_LOCAL_IP:port"` to `""`: in development mode the `url` to which Yivi apps will connect is set by default to your current local IP address; in `production` mode you must configure it yourself.
 * [`no_auth`](#requestor-authentication) from `true` to `false`: you should consider enabling requestor authentication, or explicitly disable this by setting this flag to `true`.
 * [`issue_perms`](#global-permissions) from `[*]` (everything) to `[]` (none).
-* [`no_email`](#email) from `true` to `false`: in `production` mode, opting out of providing an email address can be done by explicitly setting this flag to `true`.
 
 In addition, when [developer mode is not enabled in the Yivi app](yivi-app.md#developer-mode) (the default setting), the Yivi app wil refuse to perform sessions with IRMA servers not running in `production` mode. Since the majority of the Yivi app users will not have developer mode enabled, this requires IRMA servers facing those users to enable `production` mode.
 
@@ -294,21 +293,6 @@ The [IRMA protocol](irma-protocol.md) relies on TLS for encryption of the attrib
 You can enable TLS in the `irma server` with the `tls_cert` and `tls_privkey` options (or the `_file` equivalents), specifying a PEM certificate (chain) and PEM private key. If you use [separate requestor and app endpoints](#http-server-endpoints), additionally use `client_tls_cert` and `client_tls_privkey`.
 
 Alternatively, if your IRMA server is connected to the internet through a reverse proxy then your reverse proxy probably handles TLS for you.
-
-### Email
-
-IRMA has a decentral architecture: anyone can start an `irma server` and verify attributes, communicating directly with Yivi apps. This is an important and distinguishing feature contributing to IRMA's privacy properties and trustworthiness, but it also means that we as authors of the software have no natural update channel for all IRMA servers running within the ecosystem. We need a way to prevent a fractured IRMA ecosystem with incompatible apps and servers.
-
-Inspired by the approach of Let's Encrypt, each IRMA server can be configured with an `email` option. If specified, the address is uploaded to the [Privacy by Design Foundation](https://privacybydesign.foundation/) and subscribed to receive notifications about changes in the IRMA software or ecosystem — for example major IRMA server releases, or breaking changes that require operators to update their server or take other action.
-
-***We strongly recommend anyone running an IRMA server in production to specify an email address.***
-
-* The Foundation uses the address exclusively for the above purpose.
-* Volume is very low (on average perhaps one email per several months).
-* To unsubscribe, contact Yivi support at [support@yivi.app](mailto:support@yivi.app).
-* See also Yivi's [privacy policy](https://yivi.app/privacy/).
-
-In `production` mode, it is required to either provide an email address or to explicitly opt out with the `no_email` option.
 
 ### Logging and verbosity
 


### PR DESCRIPTION
## Summary

The `privacybydesign.foundation/serverinfo/` subscription endpoint no longer exists. The matching irmago PR ([privacybydesign/irmago#550](https://github.com/privacybydesign/irmago/pull/550)) removes the outbound POST, drops the production-mode requirement, and deprecates the `--email` / `-e` and `--no-email` flags. This docs PR removes the now-incorrect descriptions of that feature.

- Drop the `no_email` row from the `irma server` production-mode defaults list.
- Remove the dedicated **Email** section describing the (now defunct) PBDF subscription and the production-mode requirement.

## Test plan

- [x] No other docs files link to the removed section (`grep` for `email.md` / `#email`).
- [ ] Reviewer: confirm the docs site builds (Docusaurus broken-link check) once merged.

Companion to privacybydesign/irmago#550. Fixes part of privacybydesign/irmago#549 on the docs side.