### PR TITLE
docs: replace attribute-index.yivi.app with portal.yivi.app/attribute-index

### DIFF
--- a/yivi-docs/docs/getting-started.md
+++ b/yivi-docs/docs/getting-started.md
@@ -108,7 +108,7 @@ you can perform a first IRMA session using your server on the command line as fo
     ```
   </TabItem>
 </Tabs>
-[IRMATube attributes](https://portal.yivi.app/attribute-index) are available on the [YiviTube demo](https://yivitube.yivi.app/) page. This will print a QR that you can scan with your Yivi app, and the attribute contents after they have been received and verified by the server. `irma session` can also perform issuance sessions and attribute-based signature sessions. If you pass  `-v` it logs the session request JSON that it sends to your `irma server`.
+[IRMATube attributes](https://portal.yivi.app/attribute-index/credentials/production/pbdf/irmatube) are available on the [YiviTube demo](https://yivitube.yivi.app/) page. This will print a QR that you can scan with your Yivi app, and the attribute contents after they have been received and verified by the server. `irma session` can also perform issuance sessions and attribute-based signature sessions. If you pass  `-v` it logs the session request JSON that it sends to your `irma server`.
 
 
 ### Installing an example webpage for `yivi-frontend`
@@ -207,7 +207,7 @@ Instead of managing sessions with HTTP requests as shown here, [for certain lang
 
 The IRMA quickstart above mostly focuses on verifying — receiving IRMA attributes from Yivi apps and establishing their authenticity. Issuing attributes to Yivi apps can be done with the same software and largely similar flows, but is more involved, because the identity of prospective issuers needs to be verified and the contents and structure of the credentials to be issued needs to be established. This process is documented in the [issuer guide](issuer.md).
 
-For experimenting and demoing, however, it is possible to issue [any of the existing credentials](https://portal.yivi.app/attribute-index) within the [`irma-demo` scheme](schemes.md). For example, if the `requestors` block in the [YAML example configuration](#configure-irma-server) of the IRMA server above would include permission to issue `irma-demo` attributes, as follows:
+For experimenting and demoing, however, it is possible to issue [any of the existing credentials](https://portal.yivi.app/attribute-index/environments/demo) within the [`irma-demo` scheme](schemes.md). For example, if the `requestors` block in the [YAML example configuration](#configure-irma-server) of the IRMA server above would include permission to issue `irma-demo` attributes, as follows:
 
 ```yaml
 requestors:

--- a/yivi-docs/docs/getting-started.md
+++ b/yivi-docs/docs/getting-started.md
@@ -108,7 +108,7 @@ you can perform a first IRMA session using your server on the command line as fo
     ```
   </TabItem>
 </Tabs>
-[IRMATube attributes](https://attribute-index.yivi.app/en/pbdf.pbdf.irmatube.html) are available on the [YiviTube demo](https://yivitube.yivi.app/) page. This will print a QR that you can scan with your Yivi app, and the attribute contents after they have been received and verified by the server. `irma session` can also perform issuance sessions and attribute-based signature sessions. If you pass  `-v` it logs the session request JSON that it sends to your `irma server`.
+[IRMATube attributes](https://portal.yivi.app/attribute-index) are available on the [YiviTube demo](https://yivitube.yivi.app/) page. This will print a QR that you can scan with your Yivi app, and the attribute contents after they have been received and verified by the server. `irma session` can also perform issuance sessions and attribute-based signature sessions. If you pass  `-v` it logs the session request JSON that it sends to your `irma server`.
 
 
 ### Installing an example webpage for `yivi-frontend`
@@ -207,7 +207,7 @@ Instead of managing sessions with HTTP requests as shown here, [for certain lang
 
 The IRMA quickstart above mostly focuses on verifying — receiving IRMA attributes from Yivi apps and establishing their authenticity. Issuing attributes to Yivi apps can be done with the same software and largely similar flows, but is more involved, because the identity of prospective issuers needs to be verified and the contents and structure of the credentials to be issued needs to be established. This process is documented in the [issuer guide](issuer.md).
 
-For experimenting and demoing, however, it is possible to issue [any of the existing credentials](https://attribute-index.yivi.app/en/irma-demo.html) within the [`irma-demo` scheme](schemes.md). For example, if the `requestors` block in the [YAML example configuration](#configure-irma-server) of the IRMA server above would include permission to issue `irma-demo` attributes, as follows:
+For experimenting and demoing, however, it is possible to issue [any of the existing credentials](https://portal.yivi.app/attribute-index) within the [`irma-demo` scheme](schemes.md). For example, if the `requestors` block in the [YAML example configuration](#configure-irma-server) of the IRMA server above would include permission to issue `irma-demo` attributes, as follows:
 
 ```yaml
 requestors:

--- a/yivi-docs/docs/issuer.md
+++ b/yivi-docs/docs/issuer.md
@@ -47,7 +47,7 @@ Some notes about the `irma-demo` scheme:
 
 Once your modifcations are complete, ensure the scheme is validly signed by running `irma scheme sign` in your irma-demo checkout, and submit your changes as a [PR](https://github.com/privacybydesign/irma-demo-schememanager/compare). Once the PR is merged, your demo issuer and its credentials become available for issuance to your IRMA server when it updates its copy of the scheme: periodically (hourly by default), or when you restart your server.
 
-You can then use your IRMA server to issue the new credentials to your Yivi app. Alternatively, after the `irma-demo` PR is merged, the new credentials can also be issued from their corresponding pages in the [attribute index](https://privacybydesign.foundation/attribute-index/en/) (only in the case of `irma-demo` credentials).
+You can then use your IRMA server to issue the new credentials to your Yivi app. Alternatively, after the `irma-demo` PR is merged, the new credentials can also be issued from their corresponding pages in the [attribute index](https://portal.yivi.app/attribute-index/environments/demo) (only in the case of `irma-demo` credentials).
 
 #### Using a locally modified `irma-demo` scheme
 
@@ -72,7 +72,7 @@ After the development phase of your issuance application is finished and the iss
 3. [Generate](#generating-irma-issuer-keys) a new 2048 bit IRMA issuer private/public keypair; put the public key within your issuer folder in `PublicKeys/0.xml`; and keep your private key private.
 4. Submit your changes to `pbdf` as a PR.
 
-Your PR will then be signed by us, and merged. As with `irma-demo`, your issuer and its credentials then become available for issuance to your IRMA server when it updates its copy of the scheme: periodically (hourly by default), or when you restart your server. Your credentials will also automatically appear in the [attribute index](https://privacybydesign.foundation/attribute-index/en/), but in contrast with `irma-demo` credentials, they cannot be issued from there.
+Your PR will then be signed by us, and merged. As with `irma-demo`, your issuer and its credentials then become available for issuance to your IRMA server when it updates its copy of the scheme: periodically (hourly by default), or when you restart your server. Your credentials will also automatically appear in the [attribute index](https://portal.yivi.app/attribute-index), but in contrast with `irma-demo` credentials, they cannot be issued from there.
 
 ### Generating IRMA issuer keys
 

--- a/yivi-docs/docs/randomblind.md
+++ b/yivi-docs/docs/randomblind.md
@@ -54,7 +54,7 @@ We explain in detail how this comes to pass in the next section.
 
 As a concrete example we use the
 "Demo Voting Card" credential type, see [this page in the attribute
-index](https://attribute-index.yivi.app/en/irma-demo.stemmen.stempas.html#irma-demo.stemmen.stempas.election).
+index](https://portal.yivi.app/attribute-index).
 Even though the credential contains five attributes, the issuer must only give
 four concrete values to construct the credential. For example, a requestor can
 start an issuance session to issue such a credential using the following

--- a/yivi-docs/docs/randomblind.md
+++ b/yivi-docs/docs/randomblind.md
@@ -54,7 +54,7 @@ We explain in detail how this comes to pass in the next section.
 
 As a concrete example we use the
 "Demo Voting Card" credential type, see [this page in the attribute
-index](https://portal.yivi.app/attribute-index).
+index](https://portal.yivi.app/attribute-index/credentials/demo/stemmen/stempas).
 Even though the credential contains five attributes, the issuer must only give
 four concrete values to construct the credential. For example, a requestor can
 start an issuance session to issue such a credential using the following

--- a/yivi-docs/docs/session-requests.md
+++ b/yivi-docs/docs/session-requests.md
@@ -135,7 +135,7 @@ Disclosure sessions are started with an [`irma.DisclosureRequest`](https://godoc
 
 This asks for a (demo) `BSN` attribute, as well as either `street`, `houseNumber` and `city` from `irma-demo.nijmegen.address`, or `address` and `city` from `irma-demo.idin.idin`. The three levels correspond to a *conjunction* of *disjunctions* of *conjunctions* of requested attributes, allowing verifiers to request multiple attribute sets from the user, offering choices for some or all of these sets.
 
-All of the attribute types (i.e., the string values) contained in the request must exist in their scheme ([`irma-demo`](https://github.com/privacybydesign/irma-demo-schememanager) in the example above). For the `irma-demo` and `pbdf` schemes, an index of existing attribute types that can be requested can be found [here](https://attribute-index.yivi.app/en/).
+All of the attribute types (i.e., the string values) contained in the request must exist in their scheme ([`irma-demo`](https://github.com/privacybydesign/irma-demo-schememanager) in the example above). For the `irma-demo` and `pbdf` schemes, an index of existing attribute types that can be requested can be found [here](https://portal.yivi.app/attribute-index).
 
 > Attributes can be disclosed to the requestor in any of the three session types: in issuance sessions issuance proceeds only if the user discloses the required attributes just before issuance, and in attribute-based signature sessions the requested attributes are attached to the resulting attribute-based signature. Thus the `disclose` and `labels` fields introduced above can also occur in issuance or attribute-based signature session requests (see below).
 

--- a/yivi-docs/docs/technical-overview.md
+++ b/yivi-docs/docs/technical-overview.md
@@ -76,7 +76,7 @@ In this table, the right column are the attribute values which are stored and si
 
 ### Singletons
 
-A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example:  [`pbdf.nijmegen.bsn`](https://attribute-index.yivi.app/en/pbdf.nijmegen.bsn.html) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://attribute-index.yivi.app/en/pbdf.pbdf.diploma.html), then the user can have any number of instances of that credential type in her Yivi app.
+A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example:  [`pbdf.nijmegen.bsn`](https://portal.yivi.app/attribute-index) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://portal.yivi.app/attribute-index), then the user can have any number of instances of that credential type in her Yivi app.
 
 ### Special attributes
 
@@ -109,7 +109,7 @@ Each IRMA issuer has an Idemix private key, which it must keep secret as it is u
 
 Issuers cannot independently create credential types and start issuing them to Yivi app users: the credential type must first be included in an [IRMA scheme](schemes.md) by the scheme manager. In case of the default scheme `pbdf` of the Yivi app, this is the Privacy by Design Foundation.
 
-When verifying IRMA attributes, out of all possible attributes the verifier could ask for, it must decide which attributes suite its purposes best. In order to be able to make this decision, it is important that for each credential type it is clearly documented how the attributes are obtained, and how it is ensured that they indeed belong to the person that receives them. For each credential type in the `pbdf` scheme, this is documented in the [attribute index](https://attribute-index.yivi.app/en/pbdf.html). 
+When verifying IRMA attributes, out of all possible attributes the verifier could ask for, it must decide which attributes suite its purposes best. In order to be able to make this decision, it is important that for each credential type it is clearly documented how the attributes are obtained, and how it is ensured that they indeed belong to the person that receives them. For each credential type in the `pbdf` scheme, this is documented in the [attribute index](https://portal.yivi.app/attribute-index). 
 
 ## IRMA PIN codes using the keyshare server
 

--- a/yivi-docs/docs/technical-overview.md
+++ b/yivi-docs/docs/technical-overview.md
@@ -76,7 +76,7 @@ In this table, the right column are the attribute values which are stored and si
 
 ### Singletons
 
-A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example:  [`pbdf.nijmegen.bsn`](https://portal.yivi.app/attribute-index) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://portal.yivi.app/attribute-index), then the user can have any number of instances of that credential type in her Yivi app.
+A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example:  [`pbdf.nijmegen.bsn`](https://portal.yivi.app/attribute-index/credentials/production/nijmegen/bsn) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://portal.yivi.app/attribute-index/credentials/production/pbdf/diploma), then the user can have any number of instances of that credential type in her Yivi app.
 
 ### Special attributes
 
@@ -109,7 +109,7 @@ Each IRMA issuer has an Idemix private key, which it must keep secret as it is u
 
 Issuers cannot independently create credential types and start issuing them to Yivi app users: the credential type must first be included in an [IRMA scheme](schemes.md) by the scheme manager. In case of the default scheme `pbdf` of the Yivi app, this is the Privacy by Design Foundation.
 
-When verifying IRMA attributes, out of all possible attributes the verifier could ask for, it must decide which attributes suite its purposes best. In order to be able to make this decision, it is important that for each credential type it is clearly documented how the attributes are obtained, and how it is ensured that they indeed belong to the person that receives them. For each credential type in the `pbdf` scheme, this is documented in the [attribute index](https://portal.yivi.app/attribute-index). 
+When verifying IRMA attributes, out of all possible attributes the verifier could ask for, it must decide which attributes suite its purposes best. In order to be able to make this decision, it is important that for each credential type it is clearly documented how the attributes are obtained, and how it is ensured that they indeed belong to the person that receives them. For each credential type in the `pbdf` scheme, this is documented in the [attribute index](https://portal.yivi.app/attribute-index/environments/production). 
 
 ## IRMA PIN codes using the keyshare server
 

--- a/yivi-docs/docs/technical-overview.md
+++ b/yivi-docs/docs/technical-overview.md
@@ -76,7 +76,7 @@ In this table, the right column are the attribute values which are stored and si
 
 ### Singletons
 
-A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example:  [`pbdf.nijmegen.bsn`](https://portal.yivi.app/attribute-index/credentials/production/nijmegen/bsn) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://portal.yivi.app/attribute-index/credentials/production/pbdf/diploma), then the user can have any number of instances of that credential type in her Yivi app.
+A credential type can be marked as a *singleton* by the scheme manager. If so the Yivi app will store at most one instance of this credential type simultaneously, and receiving a new one would overwrite any older instance. (Example: [`pbdf.nijmegen.bsn`](https://portal.yivi.app/attribute-index/credentials/production/nijmegen/bsn).) If a credential type is not a singleton (example: [`pbdf.pbdf.diploma`](https://portal.yivi.app/attribute-index/credentials/production/pbdf/diploma)), then the user can have any number of instances of that credential type in her Yivi app.
 
 ### Special attributes
 

--- a/yivi-docs/docusaurus.config.ts
+++ b/yivi-docs/docusaurus.config.ts
@@ -112,7 +112,7 @@ const config: Config = {
         },
         { to: "/blog", label: "Blog", position: "left" },
         {
-          href: "https://attribute-index.yivi.app/en/",
+          href: "https://portal.yivi.app/attribute-index",
           label: "Attribute Index",
           position: "right",
         },


### PR DESCRIPTION
## Summary

- Replace all live doc references to `attribute-index.yivi.app` with `https://portal.yivi.app/attribute-index`
- Affected files: `docusaurus.config.ts` (navbar link), `getting-started.md`, `session-requests.md`, `technical-overview.md`, `randomblind.md`
- Blog posts referencing the old URL are intentionally left unchanged — they are historical migration records documenting when the site moved

Part of sunsetting the `attribute-index` and `attribute-index-ops` repos.