### PR TITLE
ci: skip SARIF upload on release events

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -70,10 +70,6 @@ jobs:
 
       - name: Upload Anchore scan SARIF report
         uses: github/codeql-action/upload-sarif@v4
-        # codeql-action needs a ref to attribute results to; release events carry
-        # no GITHUB_REF it accepts, so skip the upload there. The scan above still
-        # gates the build (fail-build on critical). ponytail: re-add release uploads
-        # if/when codeql-action stops requiring GITHUB_REF on release events.
         if: ${{ !cancelled() && github.event_name != 'release' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -70,7 +70,11 @@ jobs:
 
       - name: Upload Anchore scan SARIF report
         uses: github/codeql-action/upload-sarif@v4
-        if: ${{ !cancelled() }}
+        # codeql-action needs a ref to attribute results to; release events carry
+        # no GITHUB_REF it accepts, so skip the upload there. The scan above still
+        # gates the build (fail-build on critical). ponytail: re-add release uploads
+        # if/when codeql-action stops requiring GITHUB_REF on release events.
+        if: ${{ !cancelled() && github.event_name != 'release' }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 


### PR DESCRIPTION
## Why

The Delivery workflow fails on **every release** (most recently [v1.6.3](https://github.com/privacybydesign/irma-documentation/actions/runs/27955653168/job/82725958401)) at the **Upload Anchore scan SARIF report** step:

```
##[error]GITHUB_REF environment variable must be set
```

The workflow itself is unchanged — v1.6.0/1/2 published fine. `github/codeql-action/upload-sarif@v4` is a *floating* tag, and a patch shipped upstream between Jun 16–22 now hard-requires `GITHUB_REF`. On `release` events that ref is empty (push → `refs/heads/master`, PR → `refs/pull/..`, but release carries no ref codeql accepts), so the step throws. Same-day `push`/`pull_request`/`schedule` runs pass — only `release` breaks.

**Impact:** the failed step short-circuits the implicit `success()` gate, so `Push image to GitHub Container Registry` was skipped — the release image never reached ghcr.

## Fix

The `Scan Image` step already gates the build (`fail-build: true`, `severity-cutoff: critical`); the SARIF *upload* is only Security-tab reporting, and a release tag isn't a meaningful code-scanning ref. Skip the upload on release events — push/PR/schedule still populate the Security tab, and the image now publishes on release.

```yaml
if: ${{ !cancelled() && github.event_name != 'release' }}
```

A skipped step (unlike a failed one) keeps `success()` true, so the push step proceeds.

## Follow-up

v1.6.3's image still isn't on ghcr (its run skipped the push). After this merges, re-run that job or re-publish the release to push v1.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)